### PR TITLE
Fixed javaagent config overriding jvmArgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 *.ipr
 *.iws
 out
+gradle.properties

--- a/src/main/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureAction.java
+++ b/src/main/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureAction.java
@@ -108,12 +108,13 @@ public class GrailsLaunchConfigureAction implements Action<JavaExecSpec> {
         String agentJarFilePath;
         agentJarFilePath = agentJarFile.getAbsolutePath();
 
+        List<String> newJvmArgs = new ArrayList<String>();
         if(exec.getJvmArgs() != null){
-            exec.getJvmArgs().add(String.format("-javaagent:%s", agentJarFilePath));
-            exec.getJvmArgs().add("-noverify");
-        } else {
-            exec.jvmArgs(String.format("-javaagent:%s", agentJarFilePath), "-noverify"); //this may still override other args
+            newJvmArgs.addAll(exec.getJvmArgs());
         }
+        newJvmArgs.add(String.format("-javaagent:%s", agentJarFilePath));
+        newJvmArgs.add("-noverify");
+        exec.setJvmArgs(newJvmArgs);
         exec.systemProperty("springloaded", "profile=grails");
     }
 

--- a/src/main/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureAction.java
+++ b/src/main/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureAction.java
@@ -108,7 +108,12 @@ public class GrailsLaunchConfigureAction implements Action<JavaExecSpec> {
         String agentJarFilePath;
         agentJarFilePath = agentJarFile.getAbsolutePath();
 
-        exec.jvmArgs(String.format("-javaagent:%s", agentJarFilePath), "-noverify");
+        if(exec.getJvmArgs() != null){
+            exec.getJvmArgs().add(String.format("-javaagent:%s", agentJarFilePath));
+            exec.getJvmArgs().add("-noverify");
+        } else {
+            exec.jvmArgs(String.format("-javaagent:%s", agentJarFilePath), "-noverify"); //this may still override other args
+        }
         exec.systemProperty("springloaded", "profile=grails");
     }
 


### PR DESCRIPTION
The previous version of the `configureReloadAgent()` method would override ALL existing jvmArgs of the `JavaExecSpec` to set the `-javaagent` argument. This change checks if there are existing java arguments first, and if there are, adds to them instead of replacing them.
