### PR TITLE
Pass grailsHome to launcher via system property when available

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureAction.java
+++ b/src/main/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureAction.java
@@ -56,6 +56,9 @@ public class GrailsLaunchConfigureAction implements Action<JavaExecSpec> {
             oos.writeObject(launchContext);
 
             javaExec.setWorkingDir(launchContext.getBaseDir());
+            if (launchContext.getGrailsHome() != null) {
+                javaExec.systemProperty("grails.home", launchContext.getGrailsHome().getAbsolutePath());
+            }
 
             File launcherJar = findJarFile(ForkedGrailsLauncher.class);
             javaExec.classpath(launcherJar);

--- a/src/test/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureActionSpec.groovy
+++ b/src/test/groovy/org/grails/gradle/plugin/internal/GrailsLaunchConfigureActionSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grails.gradle.plugin.internal
+
+import org.gradle.api.logging.Logger
+import org.gradle.process.JavaExecSpec
+import org.grails.launcher.context.GrailsLaunchContext
+import org.grails.launcher.context.SerializableGrailsLaunchContext
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class GrailsLaunchConfigureActionSpec extends Specification {
+    @Rule final TemporaryFolder dir = new TemporaryFolder()
+
+    File grailsHome
+    File contextDestination
+    GrailsLaunchContext launchContext = new SerializableGrailsLaunchContext()
+    Logger logger = Mock()
+    JavaExecSpec javaExecSpec = Mock()
+    GrailsLaunchConfigureAction launchConfigureAction
+
+    def setup() {
+        grailsHome = dir.newFolder()
+        contextDestination = dir.newFile()
+        launchConfigureAction = new GrailsLaunchConfigureAction(launchContext, contextDestination, logger)
+    }
+
+    def "grails home is passed as a system property to launcher when set"() {
+        given:
+        launchContext.buildDependencies = []
+
+        when: "the action is executed without grailsHome set"
+        launchConfigureAction.execute(javaExecSpec)
+
+        then:
+        0 * javaExecSpec.systemProperty("grails.home", _)
+
+        when: "the action is executed with grailsHome set"
+        launchContext.grailsHome = grailsHome
+        launchConfigureAction.execute(javaExecSpec)
+
+        then:
+        1 * javaExecSpec.systemProperty("grails.home", grailsHome.absolutePath)
+    }
+}


### PR DESCRIPTION
Grails depends on grails.home being set for some features.  This plugin already
had some support for providing a grailsHome via project property (which can
either be set on the command-line or by assigning a value to "ext.grailsHome" in
the build script), but this value wasn't being passed to the launcher so that it can
be used.  In particular, after this change, if you set the grailsHome project property,
when running the grails-run-app task, Environment.isDevelopmentMode() should
now return true.

I attempted to create an integration test for this, but didn't come up with a good way to get it working repeatably across different environments.  In order to test it, the test would need acces to a grails installation.
