### PR TITLE
Update the default version of springloaded to 1.1.3

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/internal/DefaultGrailsProject.java
+++ b/src/main/groovy/org/grails/gradle/plugin/internal/DefaultGrailsProject.java
@@ -27,7 +27,7 @@ import java.io.FilenameFilter;
 
 public class DefaultGrailsProject implements GrailsProject {
 
-    public static final String DEFAULT_SPRINGLOADED = "1.1.1";
+    public static final String DEFAULT_SPRINGLOADED = "1.1.3";
 
     private final Project project;
 


### PR DESCRIPTION
Matches the version used in Grails 2.2.3
Fixes test failure:
[main] ERROR agent.SpringLoadedPreProcessor  - Unexpected problem transforming call sites
during 'can create grails 2.0.0 project'
