### PR TITLE
Add project property to toggle debug support

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/GrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/GrailsPlugin.groovy
@@ -31,6 +31,7 @@ class GrailsPlugin implements Plugin<Project> {
     static public final GRAILS_TASK_PREFIX = "grails-"
     static public final GRAILS_ARGS_PROPERTY = 'grailsArgs'
     static public final GRAILS_ENV_PROPERTY = 'grailsEnv'
+    static public final GRAILS_DEBUG_PROPERTY = 'grailsDebug'
 
     void apply(Project project) {
         project.plugins.apply(BasePlugin)
@@ -132,6 +133,9 @@ class GrailsPlugin implements Plugin<Project> {
                     }
                     if (project.hasProperty(GRAILS_ENV_PROPERTY)) {
                         env project.property(GRAILS_ENV_PROPERTY)
+                    }
+                    if (project.hasProperty(GRAILS_DEBUG_PROPERTY)) {
+                        jvmOptions.debug = Boolean.parseBoolean(project.property(GRAILS_DEBUG_PROPERTY))
                     }
                 }
             }


### PR DESCRIPTION
Enable debug by setting the project property 'grailsDebug' to 'true'

e.g.  `gradlew -PgrailsDebug=true grails-run-app`

This commit references #23
