### PR TITLE
Changed depedencies to dependencies for sample with Tomcat and bootstrap dependencies

### DIFF
--- a/src/docs/guide/usage/run.gdoc
+++ b/src/docs/guide/usage/run.gdoc
@@ -9,7 +9,7 @@ Grails does not ship with an application container provided, so the build must s
 this will be the Grails tomcat plugin:
 
 {code}
-depedencies {
+dependencies {
     bootstrap 'org.grails.plugins:tomcat:7.0.50'
 }
 {code}


### PR DESCRIPTION
There was a typo in the run.gdoc file for depedencies, which is changed to dependencies (the extra n).
