### PR TITLE
Missing 'classpath' in gradle config file

### DIFF
--- a/src/docs/guide/introduction/quickstart.gdoc
+++ b/src/docs/guide/introduction/quickstart.gdoc
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        'org.grails:grails-gradle-plugin:2.1.0'
+        classpath 'org.grails:grails-gradle-plugin:2.1.0'
     }
 }
 


### PR DESCRIPTION
Fix a small mistake in gradle config that miss 'classpath'
