### PR TITLE
Explicitly get the EclipseModel so that the plug-in works with gradle 2.3+

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/eclipse/GrailsEclipseConfigurator.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/eclipse/GrailsEclipseConfigurator.groovy
@@ -44,6 +44,7 @@ class GrailsEclipseConfigurator {
     void configure(Project project) {
         project.plugins.withType(EclipsePlugin) {
             project.eclipse {
+                def model = project.extensions.getByType(EclipseModel.class)
                 createEclipseProject(project, model)
                 createEclipseClasspath(project, model)
             }


### PR DESCRIPTION
The previous code worked fine until gradle version 2.3.  In 2.3, an implicit model object is not available and needs to be explicitly retrieved.  The 1 line change is also backwards compatible with 2.2.

The following console output demonstrates the issue.  In the example, the grails project was created with grails 2.4.2. and had the eclipse plugin applied.

wendells-mbp:gradletest wbeckwith$ /Volumes/Data/tools/gradle-2.2/bin/gradle --version

---
## Gradle 2.2.1

Build time:   2014-11-24 09:45:35 UTC
Build number: none
Revision:     6fcb59c06f43a4e6b1bcb401f7686a8601a1fb4a

Groovy:       2.3.6
Ant:          Apache Ant(TM) version 1.9.3 compiled on December 23 2013
JVM:          1.7.0_75 (Oracle Corporation 24.75-b04)
OS:           Mac OS X 10.10.2 x86_64

wendells-mbp:gradletest wbeckwith$ /Volumes/Data/tools/gradle-2.2/bin/gradle clean -S
:clean UP-TO-DATE

BUILD SUCCESSFUL

Total time: 3.299 secs
wendells-mbp:gradletest wbeckwith$ /Volumes/Data/tools/gradle-2.x/bin/gradle --version

---
## Gradle 2.3

Build time:   2015-02-16 05:09:33 UTC
Build number: none
Revision:     586be72bf6e3df1ee7676d1f2a3afd9157341274

Groovy:       2.3.9
Ant:          Apache Ant(TM) version 1.9.3 compiled on December 23 2013
JVM:          1.7.0_75 (Oracle Corporation 24.75-b04)
OS:           Mac OS X 10.10.2 x86_64

wendells-mbp:gradletest wbeckwith$ /Volumes/Data/tools/gradle-2.x/bin/gradle clean -S

FAILURE: Build failed with an exception.
- Where:
  Build file '/Users/wbeckwith/git/gradletest/build.gradle' line: 14
- What went wrong:
  A problem occurred evaluating root project 'gradletest'.
  
  > Failed to apply plugin [id 'grails']
  > Could not find property 'model' on org.gradle.plugins.ide.eclipse.model.EclipseModel_Decorated@2dea2883.
- Try:
  Run with --info or --debug option to get more log output.
- Exception is:
  org.gradle.api.GradleScriptException: A problem occurred evaluating root project 'gradletest'.
  at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:54)
  at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:154)
  at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:39)
  at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:26)
  at org.gradle.configuration.project.ConfigureActionsProjectEvaluator.evaluate(ConfigureActionsProjectEvaluator.java:34)
  at org.gradle.configuration.project.LifecycleProjectEvaluator.evaluate(LifecycleProjectEvaluator.java:59)
  at org.gradle.api.internal.project.AbstractProject.evaluate(AbstractProject.java:492)
  at org.gradle.api.internal.project.AbstractProject.evaluate(AbstractProject.java:86)
  at org.gradle.execution.TaskPathProjectEvaluator.configureHierarchy(TaskPathProjectEvaluator.java:42)
  at org.gradle.configuration.DefaultBuildConfigurer.configure(DefaultBuildConfigurer.java:35)
  at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:129)
  at org.gradle.initialization.DefaultGradleLauncher.doBuild(DefaultGradleLauncher.java:106)
  at org.gradle.initialization.DefaultGradleLauncher.run(DefaultGradleLauncher.java:86)
  at org.gradle.launcher.exec.InProcessBuildActionExecuter$DefaultBuildController.run(InProcessBuildActionExecuter.java:80)
  at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:33)
  at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:24)
  at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:36)
  at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:26)
  at org.gradle.launcher.cli.RunBuildAction.run(RunBuildAction.java:51)
  at org.gradle.internal.Actions$RunnableActionAdapter.execute(Actions.java:169)
  at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:237)
  at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:210)
  at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:35)
  at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:24)
  at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:206)
  at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:169)
  at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:33)
  at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:22)
  at org.gradle.launcher.Main.doAction(Main.java:33)
  at org.gradle.launcher.bootstrap.EntryPoint.run(EntryPoint.java:45)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:606)
  at org.gradle.launcher.bootstrap.ProcessBootstrap.runNoExit(ProcessBootstrap.java:54)
  at org.gradle.launcher.bootstrap.ProcessBootstrap.run(ProcessBootstrap.java:35)
  at org.gradle.launcher.GradleMain.main(GradleMain.java:23)
  Caused by: org.gradle.api.internal.plugins.PluginApplicationException: Failed to apply plugin [id 'grails']
  at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:147)
  at org.gradle.api.internal.plugins.DefaultPluginManager.apply(DefaultPluginManager.java:102)
  at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.applyType(DefaultObjectConfigurationAction.java:113)
  at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.access$200(DefaultObjectConfigurationAction.java:36)
  at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction$3.run(DefaultObjectConfigurationAction.java:80)
  at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.execute(DefaultObjectConfigurationAction.java:136)
  at org.gradle.api.internal.project.AbstractPluginAware.apply(AbstractPluginAware.java:46)
  at org.gradle.api.plugins.PluginAware$apply.call(Unknown Source)
  at org.gradle.api.internal.project.ProjectScript.apply(ProjectScript.groovy:34)
  at org.gradle.api.Script$apply$0.callCurrent(Unknown Source)
  at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
  at build_cka6jwtdyzsx4ze30wvc6fyzh.run(/Users/wbeckwith/git/gradletest/build.gradle:14)
  at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:52)
  ... 36 more
  Caused by: groovy.lang.MissingPropertyException: Could not find property 'model' on org.gradle.plugins.ide.eclipse.model.EclipseModel_Decorated@2dea2883.
  at org.gradle.api.internal.AbstractDynamicObject.propertyMissingException(AbstractDynamicObject.java:43)
  at org.gradle.api.internal.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:35)
  at org.gradle.api.internal.CompositeDynamicObject.getProperty(CompositeDynamicObject.java:94)
  at org.gradle.plugins.ide.eclipse.model.EclipseModel_Decorated.getProperty(Unknown Source)
  at org.codehaus.groovy.runtime.InvokerHelper.getProperty(InvokerHelper.java:168)
  at groovy.lang.Closure.getPropertyTryThese(Closure.java:321)
  at groovy.lang.Closure.getPropertyDelegateFirst(Closure.java:311)
  at groovy.lang.Closure.getProperty(Closure.java:296)
  at org.codehaus.groovy.runtime.callsite.PogoGetPropertySite.getProperty(PogoGetPropertySite.java:47)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:231)
  at org.grails.gradle.plugin.eclipse.GrailsEclipseConfigurator$_configure_closure1_closure11.doCall(GrailsEclipseConfigurator.groovy:47)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:606)
  at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
  at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324)
  at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:278)
  at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1016)
  at groovy.lang.Closure.call(Closure.java:423)
  at groovy.lang.Closure.call(Closure.java:439)
  at org.gradle.api.internal.ClosureBackedAction.execute(ClosureBackedAction.java:67)
  at org.gradle.api.internal.plugins.ExtensionsStorage$ExtensionHolder.configure(ExtensionsStorage.java:145)
  at org.gradle.api.internal.plugins.ExtensionsStorage.configureExtension(ExtensionsStorage.java:69)
  at org.gradle.api.internal.plugins.DefaultConvention$ExtensionsDynamicObject.invokeMethod(DefaultConvention.java:207)
  at org.gradle.api.internal.CompositeDynamicObject.invokeMethod(CompositeDynamicObject.java:147)
  at org.gradle.api.internal.project.DefaultProject_Decorated.invokeMethod(Unknown Source)
  at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:45)
  at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
  at org.grails.gradle.plugin.eclipse.GrailsEclipseConfigurator$_configure_closure1.doCall(GrailsEclipseConfigurator.groovy:46)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:606)
  at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
  at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324)
  at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:278)
  at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1016)
  at groovy.lang.Closure.call(Closure.java:423)
  at groovy.lang.Closure.call(Closure.java:439)
  at org.gradle.api.internal.ClosureBackedAction.execute(ClosureBackedAction.java:67)
  at org.gradle.internal.Actions$FilteredAction.execute(Actions.java:201)
  at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:110)
  at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:115)
  at org.gradle.api.internal.DefaultDomainObjectCollection.withType(DefaultDomainObjectCollection.java:126)
  at org.gradle.api.DomainObjectCollection$withType.call(Unknown Source)
  at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120)
  at org.grails.gradle.plugin.eclipse.GrailsEclipseConfigurator.configure(GrailsEclipseConfigurator.groovy:45)
  at org.grails.gradle.plugin.eclipse.GrailsEclipseConfigurator$configure.call(Unknown Source)
  at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
  at org.grails.gradle.plugin.GrailsPlugin.configureEclipse(GrailsPlugin.groovy:163)
  at org.grails.gradle.plugin.GrailsPlugin$configureEclipse$3.callCurrent(Unknown Source)
  at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
  at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
  at org.grails.gradle.plugin.GrailsPlugin.apply(GrailsPlugin.groovy:147)
  at org.grails.gradle.plugin.GrailsPlugin.apply(GrailsPlugin.groovy)
  at org.gradle.api.internal.plugins.ImperativeOnlyPluginApplicator.applyImperative(ImperativeOnlyPluginApplicator.java:35)
  at org.gradle.api.internal.plugins.RulesCapablePluginApplicator.applyImperative(RulesCapablePluginApplicator.java:42)
  at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:133)
  ... 50 more

BUILD FAILED

Total time: 3.243 secs
wendells-mbp:gradletest wbeckwith$ 
